### PR TITLE
textured depth streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ ATI/AMD may also work through VAAPI (libva-mesa-driver, not tested however).
 
 The dependency is through [HVE](https://github.com/bmegli/hardware-video-encoder) implementation (see [HVE issues](https://github.com/bmegli/hardware-video-encoder/issues/5)).
 
-Tested on LattePanda Alpha and i7-7820HK laptop.
+Depth encoding (HEVC Main10) requires at least Intel KabyLake.
+
+Textured depth encoding is implemented only for D435.
+
+Tested on LattePanda Alpha and i7-7820HK laptop with Realsense D435 camera.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This includes streaming:
 - color (H.264, HEVC Main)
 - infrared (H.264, HEVC Main)
 - depth (HEVC Main10)
+- textured depth (HEVC Main10)
 
 See [unity-network-hardware-video-decoder](https://github.com/bmegli/unity-network-hardware-video-decoder) as example network decoder & renderer (color, infrared and depth).
 
@@ -92,18 +93,22 @@ Stream H.264 Realsense color/infrared video over UDP.
 Stream Realsense:
 - color/infrared with HEVC Main
 - depth with HEVC Main10
+- textured depth with HEVC Main10
 
 ```bash
-# Usage: ./realsense-nhve-hevc <host> <port> <color/ir/depth> <width> <height> <framerate> <seconds> [device] [bitrate] [depth units]
+# Usage: ./realsense-nhve-hevc <host> <port> <color/ir/depth/depth+ir> <width> <height> <framerate> <seconds> [device] [bitrate] [depth units]
 ./realsense-nhve-hevc 127.0.0.1 9766 color 640 360 30 5
 #./realsense-nhve-hevc 127.0.0.1 9766 infrared 640 360 30 5
 #./realsense-nhve-hevc 127.0.0.1 9766 depth 640 360 30 5
+#./realsense-nhve-hevc 127.0.0.1 9766 depth+ir 848 480 30 5
 #./realsense-nhve-hevc 127.0.0.1 9766 color 640 360 30 5 /dev/dri/renderD128
 #./realsense-nhve-hevc 127.0.0.1 9766 infrared 640 360 30 5 /dev/dri/renderD128
 #./realsense-nhve-hevc 127.0.0.1 9766 depth 640 360 30 5 /dev/dri/renderD128
+#./realsense-nhve-hevc 127.0.0.1 9766 depth+ir 848 480 30 5 /dev/dri/renderD128
 #./realsense-nhve-hevc 192.168.0.125 9766 color 640 360 30 50 /dev/dri/renderD128 500000
 #./realsense-nhve-hevc 192.168.0.125 9768 depth 848 480 30 50 /dev/dri/renderD128 2000000
 #./realsense-nhve-hevc 192.168.0.125 9768 depth 848 480 30 50 /dev/dri/renderD128 8000000 0.0001
+#./realsense-nhve-hevc 192.168.0.100 9768 depth+ir 848 480 30 50 /dev/dri/renderD128 8000000 0.0001
 ```
 
 You may need to specify VAAPI device if you have more than one (e.g. NVIDIA GPU + Intel CPU).

--- a/rnhve_hevc.cpp
+++ b/rnhve_hevc.cpp
@@ -51,7 +51,6 @@ const uint16_t P010LE_MAX = 0xFFC0; //in binary 10 ones followed by 6 zeroes
 
 int main(int argc, char* argv[])
 {
-	//struct nhve_hw_config hw_config = {WIDTH, HEIGHT, FRAMERATE, DEVICE, ENCODER, PIXEL_FORMAT, PROFILE, BFRAMES, BITRATE};
 	//prepare NHVE Network Hardware Video Encoder
 	struct nhve_net_config net_config = {0};
 	struct nhve_hw_config hw_config = {0};
@@ -308,6 +307,7 @@ int process_user_input(int argc, char* argv[], input_args* input, nhve_net_confi
 		cerr << argv[0] << " 192.168.0.100 9768 depth 848 480 30 500 /dev/dri/renderD128 2000000 0.000025" << endl;
 		cerr << argv[0] << " 192.168.0.100 9768 depth 848 480 30 500 /dev/dri/renderD128 2000000 0.0000125" << endl;
 		cerr << argv[0] << " 192.168.0.100 9768 depth+ir 848 480 30 500 /dev/dri/renderD128 2000000 0.0000125" << endl;
+		cerr << argv[0] << " 192.168.0.100 9768 depth+ir 848 480 30 500 /dev/dri/renderD128 8000000 0.00003125f" << endl;
 
 		return -1;
 	}
@@ -345,7 +345,7 @@ int process_user_input(int argc, char* argv[], input_args* input, nhve_net_confi
 	//with depth encoded as above
 	//the infrared plane is encoded in chroma U/V plane
 	//for explanation see:
-	//TO DO
+	//https://github.com/bmegli/hardware-video-streaming/issues/2
 
 	hw_config->profile = FF_PROFILE_HEVC_MAIN;
 


### PR DESCRIPTION
- add depth with infrared streaming for Realsense D435

For encoding details see:
https://github.com/bmegli/hardware-video-streaming/issues/2
 

implements #2 
implements encoding side of [hardware-video-streaming#2](https://github.com/bmegli/hardware-video-streaming/issues/2)