### PR TITLE
subframe by subframe sending

### DIFF
--- a/rnhve_depth_color.cpp
+++ b/rnhve_depth_color.cpp
@@ -120,7 +120,13 @@ bool main_loop(const input_args& input, rs2::pipeline& realsense, nhve *streamer
 		frame[1].linesize[0] = color.get_stride_in_bytes();
 		frame[1].data[0] = (uint8_t*) color.get_data();
 
-		if(nhve_send(streamer, f, frame) != NHVE_OK)
+		if(nhve_send(streamer, &frame[0], 0) != NHVE_OK)
+		{
+			cerr << "failed to send" << endl;
+			break;
+		}
+
+		if(nhve_send(streamer, &frame[1], 1) != NHVE_OK)
 		{
 			cerr << "failed to send" << endl;
 			break;
@@ -128,7 +134,8 @@ bool main_loop(const input_args& input, rs2::pipeline& realsense, nhve *streamer
 	}
 
 	//flush the streamer by sending NULL frame
-	nhve_send(streamer, f, NULL);
+	nhve_send(streamer, NULL, 0);
+	nhve_send(streamer, NULL, 1);
 
 	delete [] depth_uv;
 

--- a/rnhve_h264.cpp
+++ b/rnhve_h264.cpp
@@ -96,7 +96,7 @@ bool main_loop(const input_args& input, rs2::pipeline& realsense, nhve *streamer
 		frame.linesize[1] = input.stream_color ? 0 : frame.linesize[0];
 		frame.data[1] = color_data; //dummy color plane for infrared
 
-		if(nhve_send(streamer, f, &frame) != NHVE_OK)
+		if(nhve_send(streamer, &frame, 0) != NHVE_OK)
 		{
 			cerr << "failed to send" << endl;
 			break;
@@ -104,7 +104,7 @@ bool main_loop(const input_args& input, rs2::pipeline& realsense, nhve *streamer
 	}
 
 	//flush the streamer by sending NULL frame
-	nhve_send(streamer, f, NULL);
+	nhve_send(streamer, NULL, 0);
 
 	delete [] color_data;
 

--- a/rnhve_hevc.cpp
+++ b/rnhve_hevc.cpp
@@ -112,7 +112,7 @@ bool main_loop_color_infrared(const input_args& input, rs2::pipeline& realsense,
 		frame.linesize[1] = (input.stream == COLOR) ? 0 : frame.linesize[0];
 		frame.data[1] = color_data; //dummy color plane for infrared
 
-		if(nhve_send(streamer, f, &frame) != NHVE_OK)
+		if(nhve_send(streamer, &frame, 0) != NHVE_OK)
 		{
 			cerr << "failed to send" << endl;
 			break;
@@ -120,7 +120,7 @@ bool main_loop_color_infrared(const input_args& input, rs2::pipeline& realsense,
 	}
 
 	//flush the streamer by sending NULL frame
-	nhve_send(streamer, f, NULL);
+	nhve_send(streamer, NULL, 0);
 
 	delete [] color_data;
 
@@ -159,7 +159,7 @@ bool main_loop_depth(const input_args& input, rs2::pipeline& realsense, nhve *st
 		frame.data[0] = (uint8_t*) depth.get_data();
 		frame.data[1] = (uint8_t*) color_data;
 
-		if(nhve_send(streamer, f, &frame) != NHVE_OK)
+		if(nhve_send(streamer, &frame, 0) != NHVE_OK)
 		{
 			cerr << "failed to send" << endl;
 			break;
@@ -167,7 +167,7 @@ bool main_loop_depth(const input_args& input, rs2::pipeline& realsense, nhve *st
 	}
 
 	//flush the streamer by sending NULL frame
-	nhve_send(streamer, f, NULL);
+	nhve_send(streamer, NULL, 0);
 
 	delete [] color_data;
 


### PR DESCRIPTION
Use reworked network protocol that allows sending subframes one by one.
This unlocks the potential for optimizing bandwidth and latency.

Related to [MLSP#12](https://github.com/bmegli/minimal-latency-streaming-protocol/issues/12)